### PR TITLE
Create committer records without logins

### DIFF
--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -1511,15 +1511,12 @@ class Repository < ApplicationRecord
     return [] if committers.nil?
     grouped_committers = committers.map do |committer|
       next unless committer['login'].present? || committer['email'].present?
-    
-      c = host.committers.find_by(login: committer['login']) if committer['login'].present?
-      c ||= host.committers.email(committer['email']).first
-    
-      next unless c
-    
+
+      c = find_or_create_committer_record(committer)
+
       { committer_id: c.id, commit_count: committer['count'] }
     end.compact
-    
+
     grouped_committers = grouped_committers.group_by { |c| c[:committer_id] }.map do |committer_id, records|
       {
         committer_id: committer_id,
@@ -1528,11 +1525,29 @@ class Repository < ApplicationRecord
     end
   end
 
+  def find_or_create_committer_record(committer)
+    email = committer['email'].presence&.downcase
+    login = committer['login'].presence
+
+    record = host.committers.find_by(login: login) if login
+    record ||= host.committers.email(email).first if email
+
+    if record
+      emails = Array(record.emails)
+      if email && !emails.include?(email)
+        record.update(emails: (emails + [email]).uniq)
+      end
+      return record
+    end
+
+    host.committers.create!(login: login, emails: Array(email).compact)
+  end
+
   def create_committer_join_records
     committer_records.each do |record|
-      Contribution.find_or_create_by(repository_id: id, committer_id: record[:committer_id]) do |contribution|
-        contribution.commit_count = record[:commit_count]
-      end
+      contribution = Contribution.find_or_initialize_by(repository_id: id, committer_id: record[:committer_id])
+      contribution.commit_count = record[:commit_count]
+      contribution.save!
     end
   end
 

--- a/test/models/repository_test.rb
+++ b/test/models/repository_test.rb
@@ -843,3 +843,35 @@ Co-authored-by: Claude <noreply@anthropic.com>" 2>&1`
     end
   end
 end
+
+class RepositoryCommitterRecordsTest < ActiveSupport::TestCase
+  setup do
+    @host = Host.create!(name: "github.com", url: "https://github.com", kind: "github")
+    @repository = Repository.create!(host: @host, full_name: "test/repo", owner: "test")
+  end
+
+  test "committer_records creates committers without logins" do
+    @repository.committers = [
+      { "name" => "No Login", "email" => "NOLOGIN@example.com", "login" => nil, "count" => 3 }
+    ]
+
+    records = @repository.committer_records
+    committer = @host.committers.find_by(emails: ["nologin@example.com"])
+
+    assert_not_nil committer
+    assert_nil committer.login
+    assert_equal [{ committer_id: committer.id, commit_count: 3 }], records
+  end
+
+  test "committer_records creates committers with logins and merges emails" do
+    existing = @host.committers.create!(login: "octocat", emails: ["old@example.com"])
+    @repository.committers = [
+      { "name" => "Octo Cat", "email" => "new@example.com", "login" => "octocat", "count" => 2 }
+    ]
+
+    records = @repository.committer_records
+
+    assert_equal [{ committer_id: existing.id, commit_count: 2 }], records
+    assert_equal ["old@example.com", "new@example.com"], existing.reload.emails
+  end
+end


### PR DESCRIPTION
Fixes #339

## Summary
- Creates `Committer` records for committers that only have an email and no GitHub login.
- Reuses existing committer records by login or email when present.
- Merges new emails onto existing login-backed committer records.
- Updates contribution counts when rebuilding repository committer join records instead of leaving stale counts untouched.
- Adds regression coverage for no-login committers and email merging.

## Validation
- `bundle exec ruby -c app/models/repository.rb`
- `bundle exec ruby -c test/models/repository_test.rb`
- `git diff --check`

Note: full targeted Rails test is blocked locally because `bundle install` cannot complete: the locked `sitemap_generator 7.0.0` has been removed from Rubygems. I left the new tests in place for CI.