### PR TITLE
Expose repository commit chart data API

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -260,7 +260,7 @@ GEM
       concurrent-ruby (~> 1.0, >= 1.0.5)
       sidekiq (>= 7.0.0, < 9.0.0)
       thor (>= 1.0, < 3.0)
-    sitemap_generator (7.0.0)
+    sitemap_generator (7.0.1)
       builder (~> 3.0)
     sprockets (4.2.2)
       concurrent-ruby (~> 1.0)
@@ -468,7 +468,7 @@ CHECKSUMS
   shoulda-matchers (7.0.1) sha256=b4bfd8744c10e0a36c8ac1a687f921ee7e25ed529e50488d61b79a8688749c77
   sidekiq (8.1.3) sha256=a42f51aca3705d21cb50f37f5ec07e69de8708e126be4cf94b45cf15b84b3762
   sidekiq-unique-jobs (8.1.0) sha256=6a7eaa61ac408197a542350df905687b506acae2f485da03b11d28b1c367dc35
-  sitemap_generator (7.0.0) sha256=1c92269804557fc9a1836a8519a8afbdb221026a4ebbd7c23f51ace934553e3e
+  sitemap_generator (7.0.1) sha256=cb436da1c6cb073261a63c27e714e27b8292fca1e17ad503dac1db6518b3d2a8
   sprockets (4.2.2) sha256=761e5a49f1c288704763f73139763564c845a8f856d52fba013458f8af1b59b1
   sprockets-rails (3.5.2) sha256=a9e88e6ce9f8c912d349aa5401509165ec42326baf9e942a85de4b76dbc4119e
   stringio (3.2.0) sha256=c37cb2e58b4ffbd33fe5cd948c05934af997b36e0b6ca6fdf43afa234cf222e1

--- a/app/controllers/api/v1/repositories_controller.rb
+++ b/app/controllers/api/v1/repositories_controller.rb
@@ -1,5 +1,5 @@
 class Api::V1::RepositoriesController < Api::V1::ApplicationController
-  before_action :find_host, only: [:index, :show, :ping]
+  before_action :find_host, only: [:index, :show, :ping, :chart_data]
   skip_before_action :set_cache_headers, only: [:lookup, :ping]
   skip_before_action :set_api_cache_headers, only: [:lookup, :ping]
 
@@ -95,6 +95,43 @@ class Api::V1::RepositoriesController < Api::V1::ApplicationController
     end
 
     render json: { message: 'pong' }
+  end
+
+  def chart_data
+    @repository = @host.repositories.find_by!('lower(full_name) = ?', params[:id].downcase)
+    raise ActiveRecord::RecordNotFound if @repository.owner_hidden?
+
+    period = (params[:period].presence || 'month').to_sym
+    scope = @repository.commits
+    scope = scope.since(params[:start_date]) if params[:start_date].present?
+    scope = scope.until(params[:end_date]) if params[:end_date].present?
+
+    data = case params[:chart]
+           when 'commits'
+             scope.group_by_period(period, :timestamp).count
+           when 'committers'
+             scope.group_by_period(period, :timestamp).distinct.count(:author)
+           when 'average_commits_per_committer'
+             average_commits_per_committer(scope, period)
+           else
+             render json: { error: 'unknown chart' }, status: :bad_request
+             return
+           end
+
+    fresh_when @repository, public: true
+    render json: data
+  end
+
+  private
+
+  def average_commits_per_committer(scope, period)
+    commit_counts = scope.group_by_period(period, :timestamp).count
+    committer_counts = scope.group_by_period(period, :timestamp).distinct.count(:author)
+
+    commit_counts.each_with_object({}) do |(period_key, commit_count), averages|
+      committer_count = committer_counts[period_key].to_i
+      averages[period_key] = committer_count.zero? ? 0 : (commit_count.to_f / committer_count).round(2)
+    end
   end
 
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,7 @@ Rails.application.routes.draw do
         resources :repositories, constraints: { id: /.*/ }, only: [:index, :show] do
           member do
             get 'ping', to: 'repositories#ping'
+            get 'chart_data', to: 'repositories#chart_data'
           end
           resources :commits, only: [:index]
         end

--- a/test/controllers/api/v1/repositories_chart_data_test.rb
+++ b/test/controllers/api/v1/repositories_chart_data_test.rb
@@ -1,0 +1,58 @@
+require 'test_helper'
+
+class ApiV1RepositoriesChartDataTest < ActionDispatch::IntegrationTest
+  setup do
+    @host = Host.create!(name: 'GitHub', url: 'https://github.com', kind: 'github')
+    @repository = @host.repositories.create!(full_name: 'ecosyste-ms/charts', last_synced_at: Time.current, total_commits: 3, total_committers: 2)
+  end
+
+  test 'returns commit count chart data' do
+    create(:commit, repository: @repository, timestamp: Date.new(2026, 1, 10), author: 'Alice <alice@example.com>')
+    create(:commit, repository: @repository, timestamp: Date.new(2026, 1, 20), author: 'Bob <bob@example.com>')
+    create(:commit, repository: @repository, timestamp: Date.new(2026, 2, 1), author: 'Alice <alice@example.com>')
+
+    get chart_data_api_v1_host_repository_path(@host, @repository.full_name), params: {
+      chart: 'commits', period: 'month', start_date: '2026-01-01', end_date: '2026-02-28'
+    }
+
+    assert_response :success
+    data = JSON.parse(response.body)
+    assert_equal 2, data['2026-01-01']
+    assert_equal 1, data['2026-02-01']
+  end
+
+  test 'returns distinct committer chart data' do
+    create(:commit, repository: @repository, timestamp: Date.new(2026, 1, 10), author: 'Alice <alice@example.com>')
+    create(:commit, repository: @repository, timestamp: Date.new(2026, 1, 20), author: 'Alice <alice@example.com>')
+    create(:commit, repository: @repository, timestamp: Date.new(2026, 1, 25), author: 'Bob <bob@example.com>')
+
+    get chart_data_api_v1_host_repository_path(@host, @repository.full_name), params: {
+      chart: 'committers', period: 'month', start_date: '2026-01-01', end_date: '2026-01-31'
+    }
+
+    assert_response :success
+    data = JSON.parse(response.body)
+    assert_equal 2, data['2026-01-01']
+  end
+
+  test 'returns average commits per committer chart data' do
+    create(:commit, repository: @repository, timestamp: Date.new(2026, 1, 10), author: 'Alice <alice@example.com>')
+    create(:commit, repository: @repository, timestamp: Date.new(2026, 1, 20), author: 'Alice <alice@example.com>')
+    create(:commit, repository: @repository, timestamp: Date.new(2026, 1, 25), author: 'Bob <bob@example.com>')
+
+    get chart_data_api_v1_host_repository_path(@host, @repository.full_name), params: {
+      chart: 'average_commits_per_committer', period: 'month', start_date: '2026-01-01', end_date: '2026-01-31'
+    }
+
+    assert_response :success
+    data = JSON.parse(response.body)
+    assert_equal 1.5, data['2026-01-01']
+  end
+
+  test 'returns bad request for unknown chart' do
+    get chart_data_api_v1_host_repository_path(@host, @repository.full_name), params: { chart: 'unknown' }
+
+    assert_response :bad_request
+    assert_equal 'unknown chart', JSON.parse(response.body)['error']
+  end
+end


### PR DESCRIPTION
Fixes #255

## Summary
- Adds a JSON API endpoint for repository commit chart data at `/api/v1/hosts/:host_id/repositories/:id/chart_data`.
- Supports commit counts, distinct committers, and average commits per committer grouped by day/week/month/year.
- Applies `start_date` and `end_date` filters before aggregating chart data.
- Returns a 400 JSON error for unknown chart names.
- Updates `sitemap_generator` from 7.0.0 to 7.0.1 because 7.0.0 is no longer available from RubyGems and blocked local validation.

## Validation
- `/opt/homebrew/opt/ruby/bin/bundle exec ruby -c app/controllers/api/v1/repositories_controller.rb`
- `/opt/homebrew/opt/ruby/bin/bundle exec ruby -c test/controllers/api/v1/repositories_chart_data_test.rb`
- `/opt/homebrew/opt/ruby/bin/bundle exec rails db:create db:schema:load RAILS_ENV=test`
- `/opt/homebrew/opt/ruby/bin/bundle exec rails test test/controllers/api/v1/repositories_chart_data_test.rb` → 4 runs, 9 assertions, 0 failures, 0 errors, 0 skips
- `git diff --check`