### PR TITLE
Create records for unknown committers

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -260,7 +260,7 @@ GEM
       concurrent-ruby (~> 1.0, >= 1.0.5)
       sidekiq (>= 7.0.0, < 9.0.0)
       thor (>= 1.0, < 3.0)
-    sitemap_generator (7.0.0)
+    sitemap_generator (7.0.1)
       builder (~> 3.0)
     sprockets (4.2.2)
       concurrent-ruby (~> 1.0)
@@ -468,7 +468,7 @@ CHECKSUMS
   shoulda-matchers (7.0.1) sha256=b4bfd8744c10e0a36c8ac1a687f921ee7e25ed529e50488d61b79a8688749c77
   sidekiq (8.1.3) sha256=a42f51aca3705d21cb50f37f5ec07e69de8708e126be4cf94b45cf15b84b3762
   sidekiq-unique-jobs (8.1.0) sha256=6a7eaa61ac408197a542350df905687b506acae2f485da03b11d28b1c367dc35
-  sitemap_generator (7.0.0) sha256=1c92269804557fc9a1836a8519a8afbdb221026a4ebbd7c23f51ace934553e3e
+  sitemap_generator (7.0.1) sha256=1c92269804557fc9a1836a8519a8afbdb221026a4ebbd7c23f51ace934553e3e
   sprockets (4.2.2) sha256=761e5a49f1c288704763f73139763564c845a8f856d52fba013458f8af1b59b1
   sprockets-rails (3.5.2) sha256=a9e88e6ce9f8c912d349aa5401509165ec42326baf9e942a85de4b76dbc4119e
   stringio (3.2.0) sha256=c37cb2e58b4ffbd33fe5cd948c05934af997b36e0b6ca6fdf43afa234cf222e1

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -1513,9 +1513,11 @@ class Repository < ApplicationRecord
       next unless committer['login'].present? || committer['email'].present?
     
       c = host.committers.find_by(login: committer['login']) if committer['login'].present?
-      c ||= host.committers.email(committer['email']).first
-    
-      next unless c
+      c ||= host.committers.email(committer['email']).first if committer['email'].present?
+      c ||= host.committers.create!(
+        login: committer['login'].presence,
+        emails: Array(committer['email']).compact
+      )
     
       { committer_id: c.id, commit_count: committer['count'] }
     end.compact

--- a/test/models/repository_test.rb
+++ b/test/models/repository_test.rb
@@ -842,4 +842,35 @@ Co-authored-by: Claude <noreply@anthropic.com>" 2>&1`
       assert_equal false, @repository.owner_hidden?
     end
   end
+
+  test "committer_records creates records for unknown committers with an email" do
+    @repository.update!(
+      committers: [
+        { "name" => "New Committer", "email" => "new@example.com", "login" => nil, "count" => 3 }
+      ]
+    )
+
+    record = @repository.committer_records.first
+    committer = @host.committers.find(record[:committer_id])
+
+    assert_equal ["new@example.com"], committer.emails
+    assert_nil committer.login
+    assert_equal 3, record[:commit_count]
+  end
+
+  test "committer_records creates records for unknown committers with a login" do
+    @repository.update!(
+      committers: [
+        { "name" => "New Committer", "email" => nil, "login" => "new-user", "count" => 7 }
+      ]
+    )
+
+    record = @repository.committer_records.first
+    committer = @host.committers.find(record[:committer_id])
+
+    assert_equal "new-user", committer.login
+    assert_empty committer.emails
+    assert_equal 7, record[:commit_count]
+  end
+
 end


### PR DESCRIPTION
Fixes #339

## Summary
- Creates a `Committer` record when repository committer stats include a login or email that does not already match an existing committer.
- Still reuses existing committers by login or email first, then rolls duplicate stats up by committer id as before.
- Adds regression coverage for unknown email-only and login-only committers.

## Validation
- `/opt/homebrew/opt/ruby/bin/ruby -c app/models/repository.rb`
- `/opt/homebrew/opt/ruby/bin/ruby -c test/models/repository_test.rb`
- `/opt/homebrew/opt/ruby/bin/bundle exec rails db:create db:schema:load RAILS_ENV=test`
- `/opt/homebrew/opt/ruby/bin/bundle exec rails test test/models/repository_test.rb` → 53 runs, 149 assertions, 0 failures, 0 errors, 1 skip
- `git diff --check`

Note: `Gemfile.lock` updates `sitemap_generator` from 7.0.0 to 7.0.1 because 7.0.0 is no longer available from RubyGems and blocked local validation.