### PR TITLE
Add Atom feeds for host lists

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -260,7 +260,7 @@ GEM
       concurrent-ruby (~> 1.0, >= 1.0.5)
       sidekiq (>= 7.0.0, < 9.0.0)
       thor (>= 1.0, < 3.0)
-    sitemap_generator (7.0.0)
+    sitemap_generator (7.0.1)
       builder (~> 3.0)
     sprockets (4.2.2)
       concurrent-ruby (~> 1.0)
@@ -468,7 +468,7 @@ CHECKSUMS
   shoulda-matchers (7.0.1) sha256=b4bfd8744c10e0a36c8ac1a687f921ee7e25ed529e50488d61b79a8688749c77
   sidekiq (8.1.3) sha256=a42f51aca3705d21cb50f37f5ec07e69de8708e126be4cf94b45cf15b84b3762
   sidekiq-unique-jobs (8.1.0) sha256=6a7eaa61ac408197a542350df905687b506acae2f485da03b11d28b1c367dc35
-  sitemap_generator (7.0.0) sha256=1c92269804557fc9a1836a8519a8afbdb221026a4ebbd7c23f51ace934553e3e
+  sitemap_generator (7.0.1) sha256=1c92269804557fc9a1836a8519a8afbdb221026a4ebbd7c23f51ace934553e3e
   sprockets (4.2.2) sha256=761e5a49f1c288704763f73139763564c845a8f856d52fba013458f8af1b59b1
   sprockets-rails (3.5.2) sha256=a9e88e6ce9f8c912d349aa5401509165ec42326baf9e942a85de4b76dbc4119e
   stringio (3.2.0) sha256=c37cb2e58b4ffbd33fe5cd948c05934af997b36e0b6ca6fdf43afa234cf222e1

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -17,6 +17,10 @@ class ApplicationController < ActionController::Base
 
   def find_host_by_param(param_name)
     host_param = params[param_name]
+    if host_param.end_with?('.atom')
+      host_param = host_param.delete_suffix('.atom')
+      request.format = :atom
+    end
     @host = Host.find_by_name!(host_param)
     unless @host.name == host_param
       safe_params = request.query_parameters.except(:controller, :action, :host, :port, :protocol)

--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -3,8 +3,8 @@ class HostsController < ApplicationController
 
   def index
     @hosts = Host.all.visible.order('repositories_count DESC, commits_count DESC').limit(20)
-    fresh_when @hosts, public: true
     @repositories = Repository.visible.order('last_synced_at DESC').includes(:host).limit(25)
+    fresh_when @hosts, public: true
   end
 
   def show
@@ -19,5 +19,10 @@ class HostsController < ApplicationController
     end
 
     @pagy, @repositories = pagy_countless(scope)
+
+    respond_to do |format|
+      format.html
+      format.atom
+    end
   end
 end

--- a/app/views/hosts/index.atom.builder
+++ b/app/views/hosts/index.atom.builder
@@ -1,0 +1,13 @@
+atom_feed do |feed|
+  feed.title 'commits.ecosyste.ms hosts'
+  feed.updated(@repositories.first&.last_synced_at || @hosts.first&.updated_at || Time.current)
+
+  @repositories.each do |repository|
+    feed.entry(repository, url: host_repository_url(repository.host, repository)) do |entry|
+      entry.title repository.full_name
+      entry.updated repository.last_synced_at || repository.updated_at
+      entry.summary "#{repository.full_name} on #{repository.host} has #{number_with_delimiter(repository.total_commits || 0)} commits from #{number_with_delimiter(repository.total_committers || 0)} committers."
+      entry.author { |author| author.name repository.host.to_s }
+    end
+  end
+end

--- a/app/views/hosts/index.html.erb
+++ b/app/views/hosts/index.html.erb
@@ -1,5 +1,8 @@
 <% @meta_title = "Repository Hosts" %>
 <% @meta_description = "List of repository hosts that have had their commit history parsed" %>
+<% content_for :head do %>
+  <%= auto_discovery_link_tag :atom, hosts_url(format: :atom), title: 'commits.ecosyste.ms hosts' %>
+<% end %>
 
 <div class="col-lg-4 container-sm text-center">
   <form class="row g-2 justify-content-center" action='<%= lookup_repositories_path %>' method="get">

--- a/app/views/hosts/show.atom.builder
+++ b/app/views/hosts/show.atom.builder
@@ -1,0 +1,13 @@
+atom_feed do |feed|
+  feed.title "#{@host} repositories - commits.ecosyste.ms"
+  feed.updated(@repositories.first&.last_synced_at || @host.updated_at || Time.current)
+
+  @repositories.each do |repository|
+    feed.entry(repository, url: host_repository_url(@host, repository)) do |entry|
+      entry.title repository.full_name
+      entry.updated repository.last_synced_at || repository.updated_at
+      entry.summary "#{repository.full_name} has #{number_with_delimiter(repository.total_commits || 0)} commits from #{number_with_delimiter(repository.total_committers || 0)} committers."
+      entry.author { |author| author.name @host.to_s }
+    end
+  end
+end

--- a/app/views/hosts/show.html.erb
+++ b/app/views/hosts/show.html.erb
@@ -1,5 +1,8 @@
 <% @meta_title = @host.to_s %>
 <% @meta_description = "List of repositories on #{@host.to_s} that have had their commit history parsed" %>
+<% content_for :head do %>
+  <%= auto_discovery_link_tag :atom, host_url(@host, format: :atom), title: "#{@host} repositories" %>
+<% end %>
 
 <div class="container-sm">
   <h1 class='mb-4'>

--- a/test/controllers/hosts_controller_test.rb
+++ b/test/controllers/hosts_controller_test.rb
@@ -55,6 +55,23 @@ class HostsControllerTest < ActionDispatch::IntegrationTest
       assert_response :success
       assert_template 'hosts/index'
     end
+
+    should "include atom feed auto discovery link" do
+      get hosts_path
+
+      assert_response :success
+      assert_select "link[type='application/atom+xml'][href=?]", hosts_url(format: :atom)
+    end
+
+    should "render atom feed of recent repositories" do
+      repository = create(:repository, :with_commits, host: @host, full_name: "owner/feed", last_synced_at: 1.hour.ago)
+
+      get hosts_path(format: :atom)
+
+      assert_response :success
+      assert_equal 'application/atom+xml', response.media_type
+      assert_match repository.full_name, response.body
+    end
   end
 
   context "GET #show" do
@@ -77,6 +94,23 @@ class HostsControllerTest < ActionDispatch::IntegrationTest
       assert_response :success
       assert_match repo1.full_name, response.body
       assert_match repo2.full_name, response.body
+    end
+
+    should "include atom feed auto discovery link" do
+      get host_path(@host_with_repos.name)
+
+      assert_response :success
+      assert_select "link[type='application/atom+xml'][href=?]", host_url(@host_with_repos, format: :atom)
+    end
+
+    should "render atom feed of host repositories" do
+      repository = create(:repository, :with_commits, host: @host_with_repos, full_name: "owner/feed")
+
+      get host_path(@host_with_repos.name, format: :atom)
+
+      assert_response :success
+      assert_equal 'application/atom+xml', response.media_type
+      assert_match repository.full_name, response.body
     end
 
     should "only show visible repositories" do


### PR DESCRIPTION
Fixes #28

## Summary
- Adds Atom feed responses for the hosts list and each host repository list.
- Adds `<link rel="alternate" type="application/atom+xml">` auto-discovery tags to the HTML pages.
- Handles `.atom` host URLs cleanly for host names that can contain dots.
- Adds controller coverage for feed links and Atom responses.

## Validation
- `/opt/homebrew/opt/ruby/bin/ruby -c app/controllers/application_controller.rb`
- `/opt/homebrew/opt/ruby/bin/ruby -c app/controllers/hosts_controller.rb`
- `/opt/homebrew/opt/ruby/bin/ruby -c test/controllers/hosts_controller_test.rb`
- `/opt/homebrew/opt/ruby/bin/bundle exec rails test test/controllers/hosts_controller_test.rb` → 25 runs, 69 assertions, 0 failures, 0 errors, 0 skips
- `git diff --check`

Note: `Gemfile.lock` updates `sitemap_generator` from 7.0.0 to 7.0.1 because 7.0.0 is no longer available from RubyGems and blocked local validation.